### PR TITLE
Potential fix for code scanning alert no. 91: Type confusion through parameter tampering

### DIFF
--- a/lib/insecurity.js
+++ b/lib/insecurity.js
@@ -112,6 +112,9 @@ const redirectAllowlist = new Set([
 exports.redirectAllowlist = redirectAllowlist
 
 exports.isRedirectAllowed = url => {
+  if (typeof url !== 'string') {
+    url = String(url)
+  }
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
     allowed = allowed || url.includes(allowedUrl) // vuln-code-snippet vuln-line redirectChallenge


### PR DESCRIPTION
Potential fix for [https://github.com/AlonaHlobina/juice-shop/security/code-scanning/91](https://github.com/AlonaHlobina/juice-shop/security/code-scanning/91)

To fix the problem, we need to ensure that the `url` parameter in the `isRedirectAllowed` function is always a string. This can be done by checking the type of `url` and converting it to a string if it is not already. This way, we can prevent type confusion attacks and ensure the validation logic works as intended.

1. In the `isRedirectAllowed` function, check if `url` is a string.
2. If `url` is not a string, convert it to a string.
3. This change should be made in the `lib/insecurity.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
